### PR TITLE
clean up pip-pop in the `not silent` case

### DIFF
--- a/vendor/pip-pop/pip-grep
+++ b/vendor/pip-pop/pip-grep
@@ -62,7 +62,7 @@ def grep(reqfile, packages, silent=False):
                 exit(0)
 
     if not silent:
-        print('Not found.'.format(requirement.req.project_name))
+        print('Not found.')
 
     exit(1)
 


### PR DESCRIPTION
The extraneous `format` call is harmless in itself, but it's possible for `requirement.req` to be `None` here, which results in `AttributeError: 'NoneType' object has no attribute 'project_name'`.